### PR TITLE
denylist: disable podman.rootless-systemd on c9s/rhel-9.0

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -51,7 +51,8 @@
   osversion:
     - c9s
     - rhel-9.0
-- pattern: ext.config.shared.chrony.dhcp-propagation
+- pattern: ext.config.shared.podman.rootless-systemd
+  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2123246
   osversion:
     - c9s
     - rhel-9.0


### PR DESCRIPTION
Also enable chrony.dhcp-propagation.

(cherry picked from commit 40f1da8ba8a94a3acce853a0088bda9d472a7ae9)